### PR TITLE
spelling fixes

### DIFF
--- a/src/Bartlett/CompatInfoDb/Environment.php
+++ b/src/Bartlett/CompatInfoDb/Environment.php
@@ -94,14 +94,14 @@ class Environment
         $ext = 'pdo_sqlite';
         if (!extension_loaded($ext)) {
             $error .= sprintf(
-                "\n- Expected PHP extension %s loaded to use SQLite DataBase, is missing",
+                "\n- Expected PHP extension %s loaded to use SQLite DataBase, extension may be missing",
                 $ext
             );
         }
 
         if (!empty($error)) {
             throw new \RuntimeException(
-                'Your platform does not statisfy CompatInfo minimum requirements' .
+                'Your platform does not satisfy CompatInfo minimum requirements' .
                 $error
             );
         }


### PR DESCRIPTION
spelling fixes for requirement checks.

btw, imho db is wrong package for requirement checks, should code should be in app itself.

also the error message lacks trailing newline (`➔` is my shell prompt):

```
➔ ./phpcompatinfo.phar 
Your platform does not statisfy CompatInfo minimum requirements
- Expected PHP extension pdo_sqlite loaded to use SQLite DataBase, is missing➔ 
```

it's submitted as separate PR: https://github.com/llaville/php-compat-info/pull/224