### PR TITLE
allow newer version of composer/semver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": "^7.1",
-        "composer/semver": "^1.0",
+        "composer/semver": "^1.0|^2.0|^3.0",
         "ext-curl": "*",
         "ext-intl": "*",
         "ext-libxml": "*",


### PR DESCRIPTION
As this project only use `Composer\Semver\Semver::satisfies`, it is not affected by changes in newer versions
See https://github.com/composer/semver/blob/master/CHANGELOG.md
