### PR TITLE
Explicit dependency on doctrine dbal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "ext-spl": "*",
         "composer/package-versions-deprecated": "^1.8",
         "composer/semver": "^1.0|^2.0|^3.0",
+        "doctrine/dbal": "^2.13",
         "doctrine/orm": "^2.7",
         "symfony/cache": "^4.4|^5.0",
         "symfony/config": "^4.4|^5.0",


### PR DESCRIPTION
1/ really used

From phpcompatinfo report

```
  U Doctrine\DBAL\Connection                                                                    user                   5.3.0       
  U Doctrine\ORM\EntityManagerInterface                                                         user                   5.3.0       

```

2/ version 2 required

Latest version of doctrine/orm allow dbal v2 or v3

But this project doesn't support v3
```

+ /usr/bin/php -d date.timezone=Europe/Paris compatinfo-db diagnose

In HandleMessageMiddleware.php line 80:
                                                                
  Call to undefined method Doctrine\DBAL\Result::fetchColumn()  
                                                                

In ProjectRequirements.php line 146:
                                                                
  Call to undefined method Doctrine\DBAL\Result::fetchColumn()  
                                                                

diagnose [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-c|--config CONFIG] [--no-configuration] [--profile] [--] <command>

```


P.S. v2.13 is the version required by doctrine/orm 
`   "doctrine/dbal": "^2.13 || ^3.1.1"`

